### PR TITLE
The source :rubygems is deprecated because HTTP requests are insecure.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :development, :test do
   gem 'simplecov'


### PR DESCRIPTION
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
